### PR TITLE
Fix placeholder regular expression

### DIFF
--- a/FixDynamicPlaceholders.aspx.cs
+++ b/FixDynamicPlaceholders.aspx.cs
@@ -101,7 +101,7 @@ namespace Sitecore.Web.sitecore.admin
                         if (!string.IsNullOrWhiteSpace(rendering.Placeholder))
                         {
                             var newPlaceholder = rendering.Placeholder;
-                            string placeHolderRegex = "([0-9a-f]{8}[-][0-9a-f]{4}[-][0-9a-f]{4}[-][0-9a-f]{4}[-][0-9a-f]{12})$";
+                            string placeHolderRegex = "([0-9a-f]{8}[-][0-9a-f]{4}[-][0-9a-f]{4}[-][0-9a-f]{4}[-][0-9a-f]{12})";
                             foreach (Match match in Regex.Matches(newPlaceholder, placeHolderRegex, RegexOptions.IgnoreCase))
                             {
                                 var renderingId = match.Value;


### PR DESCRIPTION
Count for multi level dynamic placeholder key, remove $ from the end of the regex.

Ex: /content/column2/innercolumn1-{1e6965c3-16ae-4716-8d6e-c2bb8a0701c9}-0/subitem-{b042af26-1bb2-481a-817e-f0a7af939eef}-0/grouplinks-{d3bcf86a-717b-47a6-b403-f81375031ecd}-0